### PR TITLE
Added WORKDIR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ RUN set -x \
 
 VOLUME /swagger-api/out
 
+WORKDIR /swagger-api/out
+
 COPY docker-entrypoint.sh /
 
 RUN cd /swagger-api/swagger-codegen && \


### PR DESCRIPTION
Without the `WORKDIR`, the current working directory within the container is `/`. This results in generated output files being written to `/`, thus outside of the desired output directory `/swagger-api/out`.

Setting the `WORKDIR` to `/swagger-api/out` fixes this.