### PR TITLE
Update docker-entrypoint.sh

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,7 +4,7 @@ set -eo pipefail
 
 codegen="/swagger-api/swagger-codegen/modules/swagger-codegen-cli/target/swagger-codegen-cli.jar"
 
-JAVA_OPTS=${JAVA_OPTS:"-XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"}
+JAVA_OPTS=${JAVA_OPTS:-"-XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"}
 
 case "$1" in
     generate|help|langs|meta|config-help|version)


### PR DESCRIPTION
Added missing "-" for correct processing of JAVA_OPTS defined by "the environment" (e.g. via docker run -e JAVA_OPTS=-Dapis)